### PR TITLE
fixes #7 and adds DiscreteClass

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -23,7 +23,7 @@ Imports:
     sandwich
 License: GPL-2 | GPL-3
 Suggests: 
-    mirt (>= 1.26.3),
+    mirt (>= 1.42.1),
     OpenMx,
     tidySEM,
     AER,

--- a/R/llcont.R
+++ b/R/llcont.R
@@ -10,8 +10,8 @@
 #' @param x a model object
 #' @param \dots arguments passed to specific methods
 #'
-#' @author Ed Merkle, Dongjun You, Lennart Schneider, and Mauricio Garnier-Villarreal
-#' 
+#' @author Ed Merkle, Dongjun You, Lennart Schneider, Mauricio Garnier-Villarreal, and Phil Chalmers
+#'
 #' @return An object of class \code{numeric} containing individuals' contributions to the log-likelihood.  The sum of these contributions equals the model log-likelihood.
 #'
 #' @examples
@@ -431,7 +431,7 @@ llcont.lavaan <- function(x, ...){
         if(inherits(tmpll.x, "try-error")) tmpll.x <- NA
         llvec[grpind] <- llvec[grpind] - tmpll.x
       }
-      
+
     } else { # incomplete data
       nsub <- ntab[g]
       M <- samplestats@missing[[g]]
@@ -440,7 +440,7 @@ llcont.lavaan <- function(x, ...){
 
       Mu.hat <- unclass(moments$mean)
       nvar <- ncol(moments$cov)
-      
+
       for(p in 1:length(M)) {
         ## Data
         case.idx <- Mp$case.idx[[p]]
@@ -489,7 +489,7 @@ llcont.lavaan <- function(x, ...){
     llvec <- llvec[!is.na(llvec)]
     if(length(llvec) != sum(unlist(lavInspect(x, 'nobs')))) warning("nonnest2 warning: problem with llcont(), likely due to missing data.")
   }
-  
+
   llvec
 }
 
@@ -527,6 +527,11 @@ llcont.SingleGroupClass <- function(x, ...) {
   return(llcont)
 }
 
+#' @export
+llcont.DiscreteClass <- function(x, ...){
+    class(x) <- "MultipleGroupClass"
+    llcont(x, ...)
+}
 
 ################################################################
 ## Getting log-likelihood of OpenMx objects for individual cases
@@ -535,7 +540,7 @@ llcont.SingleGroupClass <- function(x, ...) {
 llcont.MxModel <- function(x, ...){
 
   wgts <- x$expectation$output$weights
-  
+
   if(is.null(wgts)){
     ls <- attr(OpenMx::mxEvalByName("fitfunction", x), 'likelihoods')
     if(is.null(ls)){
@@ -556,8 +561,8 @@ llcont.MxModel <- function(x, ...){
     }
     lls <- log(rowSums(ll_temp))
   }
-  
+
   return(lls)
 }
 
-              
+

--- a/R/vuongtest.R
+++ b/R/vuongtest.R
@@ -87,7 +87,7 @@
 #'
 #' vcl <- function(obj) vcov(obj, full=TRUE)
 #' vuongtest(fm1, fm2, vc1=vcl, vc2=vcl, nested=TRUE)
-#' 
+#'
 #' }
 #'
 #' @importFrom sandwich estfun
@@ -101,7 +101,7 @@ vuongtest <- function(object1, object2, nested=FALSE, adj="none", ll1=llcont, ll
   obinfo <- check.obj(object1, object2)
   callA <- obinfo$callA; classA <- obinfo$classA
   callB <- obinfo$callB; classB <- obinfo$classB
-    
+
   llA <- ll1(object1)
   llB <- ll2(object2)
 
@@ -151,7 +151,7 @@ vuongtest <- function(object1, object2, nested=FALSE, adj="none", ll1=llcont, ll
   } else {
     nparB <- length(coef(object2))
   }
-  
+
   if(adj=="aic"){
     lr <- lr - (nparA - nparB)
   }
@@ -234,7 +234,7 @@ calcAB <- function(object, n, scfun, vc){
     sc <- scfun(object)
   } else if(class(object)[1] == "lavaan"){
     sc <- estfun(object, remove.duplicated=TRUE)
-  } else if(class(object)[1] %in% c("SingleGroupClass", "MultipleGroupClass")){
+  } else if(class(object)[1] %in% c("SingleGroupClass", "MultipleGroupClass", "DiscreteClass")){
     wts <- mirt::extract.mirt(object, "survey.weights")
     if(length(wts) > 0){
       sc <- mirt::estfun.AllModelClass(object, weights = sqrt(wts))
@@ -324,18 +324,15 @@ print.vuongtest <- function(x, ...) {
 check.obj <- function(object1, object2) {
   classA <- class(object1)[1L]
   classB <- class(object2)[1L]
-  
+
   if(isS4(object1)){
-    if(classA %in% c("SingleGroupClass", "MultipleGroupClass")){
+    if(classA %in% c("SingleGroupClass", "MultipleGroupClass", "DiscreteClass")){
       callA <- object1@Call
       ## recommended vcov type for mirt models:
       if(object1@Options$SE.type != "Oakes") warning("SE.type='Oakes' is recommended for mirt models")
-    } 
+    }
       if (classA %in% c("MxRAMModel" , "MxModel")){
       callA <- object1@name
-    }
-    else {
-      callA <- object1@call
     }
     if(classA == "lavaan"){
       if(length(object1@Data@weights[[1]]) > 0){
@@ -346,15 +343,12 @@ check.obj <- function(object1, object2) {
     callA <- object1$call
   }
   if(isS4(object2)){
-    if(classB %in% c("SingleGroupClass", "MultipleGroupClass")){
+    if(classB %in% c("SingleGroupClass", "MultipleGroupClass", "DiscreteClass")){
       callB <- object2@Call
       if(object2@Options$SE.type != "Oakes") warning("SE.type='Oakes' is recommended for mirt models")
-    } 
+    }
       if (classB %in% c("MxRAMModel" , "MxModel") ){
       callB <- object2@name
-    }
-    else {
-      callB <- object2@call
     }
     if(classB == "lavaan"){
       if(length(object2@Data@weights[[1]]) > 0){
@@ -366,8 +360,8 @@ check.obj <- function(object1, object2) {
   }
 
   list(classA = classA, classB = classB, callA = callA, callB = callB)
-}  
-  
+}
+
 
 .onAttach <- function(...) {
   version <- read.dcf(file=system.file("DESCRIPTION", package="nonnest2"), fields="Version")


### PR DESCRIPTION
Hi Ed,

This fixes issue 7 that I opened by removing the `x@call` portions, and provides support for the `DiscreteClass` objects from mirt's `mdirt()` function. Please let me know if you have any questions of concerns. Cheers.
