### PR TITLE
Fix lavaan equality constraints parameter counting in vuongtest

### DIFF
--- a/R/vuongtest.R
+++ b/R/vuongtest.R
@@ -141,14 +141,17 @@ vuongtest <- function(object1, object2, nested=FALSE, adj="none", ll1=llcont, ll
   lr <- sum(llA - llB, na.rm = TRUE)
 
   ## Adjustments to likelihood ratio
-  ## FIXME lavaan equality constraints; use df instead?
   if(classA %in% c("SingleGroupClass", "MultipleGroupClass")){
     nparA <- mirt::extract.mirt(object1, "nest")
+  } else if(classA == "lavaan"){
+    nparA <- attr(logLik(object1), "df")
   } else {
     nparA <- length(coef(object1))
   }
   if(classB %in% c("SingleGroupClass", "MultipleGroupClass")){
     nparB <- mirt::extract.mirt(object2, "nest")
+  } else if(classB == "lavaan"){
+    nparB <- attr(logLik(object2), "df")
   } else {
     nparB <- length(coef(object2))
   }


### PR DESCRIPTION
Mirror PR of https://github.com/seonghobae/nonnest2/pull/2

`length(coef(object))` overcounts free parameters for lavaan models with equality constraints, since `coef()` includes duplicate entries for constrained parameters. This PR uses `attr(logLik(object), "df")` for lavaan models.